### PR TITLE
Update README.md

### DIFF
--- a/roo-ignore/README.md
+++ b/roo-ignore/README.md
@@ -19,7 +19,7 @@ wget https://raw.githubusercontent.com/Michaelzag/RooCode-Tips-Tricks/main/roo-i
 then:
 
 ```bash
-node generate-rooignore.js node generate-rooignore.js --threshold=30000
+node generate-rooignore.js --threshold=30000
 ```
 
 if it doensm't work you might need to chmod +x


### PR DESCRIPTION
Simple example command typo fix.

The listed command had `node generate-rooignore.js` appear twice, so if you just copy and paste and run the command it thinks `generate-rooignore.js` is the directory it's supposed to analyse and fails.